### PR TITLE
bundle exec everywhere

### DIFF
--- a/admin/Procfile
+++ b/admin/Procfile
@@ -1,2 +1,2 @@
-web: rails s -p 5003
-worker: env WORKERS=Blog::PostsWorker rake sneakers:run
+web: bundle exec rails s -p 5003
+worker: env WORKERS=Blog::PostsWorker bundle exec rake sneakers:run

--- a/bin/run
+++ b/bin/run
@@ -4,22 +4,26 @@ set -e
 set -x
 
 cd blog
+hash -r
 bundle check || bundle install
-rake db:migrate
+bundle exec rake db:migrate
 cd ..
 
 cd dashboard
+hash -r
 bundle check || bundle install
 cd ..
 
 cd admin
+hash -r
 bundle check || bundle install
-rake db:migrate
+bundle exec rake db:migrate
 cd ..
 
 cd config
+hash -r
 bundle check || bundle install
-rake rabbitmq:setup
+bundle exec rake rabbitmq:setup
 cd ..
 
 which foreman > /dev/null 2>&1 || gem install foreman

--- a/blog/Procfile
+++ b/blog/Procfile
@@ -1,1 +1,1 @@
-web: rails s -p 5001
+web: bundle exec rails s -p 5001

--- a/config/Gemfile
+++ b/config/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'bunny'
+gem 'rake'

--- a/config/Gemfile.lock
+++ b/config/Gemfile.lock
@@ -4,9 +4,11 @@ GEM
     amq-protocol (1.9.2)
     bunny (1.2.1)
       amq-protocol (>= 1.9.2)
+    rake (10.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bunny
+  rake

--- a/dashboard/Procfile
+++ b/dashboard/Procfile
@@ -1,2 +1,2 @@
-web: rails s -p 5002
-worker: env WORKERS=PostsWorker,PageViewsWorker rake sneakers:run
+web: bundle exec rails s -p 5002
+worker: env WORKERS=PostsWorker,PageViewsWorker bundle exec rake sneakers:run


### PR DESCRIPTION
Added `bundle exec everywhere` (because I had multiple versions of rake installed)
Added `rake` to `config/Gemfile`
Added `hash -r` to clear bash (and zsh) path cache: last `bundle check` in `bin/run`gave me `/bin/bundle: No such file or directory`. This is because bundle in `config`is inside .bin/bundle, while there is no binstub for `config` folder
